### PR TITLE
Add build GitHub Action

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,24 @@
+name: Build Python distrubutions
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install -r requirements/build_requirements.txt
+
+    - name: Build a Python source distrubution and wheel
+      run: |
+        ./scripts/build.sh


### PR DESCRIPTION
Add a GitHub Action for PRs that builds Python distributions.

For now, it just install build dependencies from
`requirements/build_requirements.txt` but the build script should
probably set up it's own venv to run in.