### PR TITLE
Change Python workflow name

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Test Python Code
 
 on: [push]
 


### PR DESCRIPTION
Change the name of the Python code testing workflow and rename the file
to (somewhat) match. Maybe the filenames should match the workflow name
exactly (in snake_case of course)?