### PR TITLE
Ascola/require complete test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+fail_under=100


### PR DESCRIPTION
Require 100% test coverage and fail if the coverage is under 100%.