### PR TITLE
Ascola/move building venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Ignore compiled bytecode files.
 *.pyc
 
-# Ignore the virtual environment used by testing and building scripts.
-venv
-
 # Ignore the virtual environments used by testing and building scripts.
 venvs
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,10 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 pushd "${SELIGIMUS}" > /dev/null
 trap "popd > /dev/null" EXIT
 
-python3 -m venv "${SELIGIMUS}/venvs/distribution_building"
-source "${SELIGIMUS}/venvs/distribution_building/bin/activate"
+VENV="${SELIGIMUS}/venvs/distribution_building"
+
+python3 -m venv "${VENV}"
+source "${VENV}/bin/activate"
 python3 -m pip install -r "${SELIGIMUS}/requirements/build_requirements.txt"
 
 python3 setup.py sdist bdist_wheel

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 pushd "${SELIGIMUS}" > /dev/null
 trap "popd > /dev/null" EXIT
 
-python3 -m venv "${SELIGIMUS}/venv"
-source "${SELIGIMUS}/venv/bin/activate"
+python3 -m venv "${SELIGIMUS}/venvs/distribution_building"
+source "${SELIGIMUS}/venvs/distribution_building/bin/activate"
 python3 -m pip install -r "${SELIGIMUS}/requirements/build_requirements.txt"
 
 python3 setup.py sdist bdist_wheel


### PR DESCRIPTION
Move the location of the virtual environment used for building
distributions into the `venvs` directory. Having one place for all venvs
will hopefully make them easier to keep track of.