### PR TITLE
Add dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ seligimus.egg-info
 build
 
 # Ignore setuptools output directory.
-dist
+dist/*
+!dist/.gitkeep


### PR DESCRIPTION
Add the `dist` directory where distributions are generated to explicitly
call out the workflow.