### PR TITLE
Add version file to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include scripts/build.sh
 include requirements/build_requirements.txt
+include VERSION.txt


### PR DESCRIPTION
Add the version file to the source distribution. This is needed to be
able to build a wheel from the source distribution because the
`setup.py` reads from it.