### PR TITLE
Ascola/change wheel testing

### DIFF
--- a/.github/workflows/distributions.yml
+++ b/.github/workflows/distributions.yml
@@ -15,7 +15,11 @@ jobs:
       with:
         python-version: 3.6
 
-    - name: Install dependencies
+    - name: Install APT dependencies
+      run: |
+        sudo apt-get install zipcmp
+
+    - name: Install Python dependencies
       run: |
         python3 -m pip install -r requirements/build_requirements.txt
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include scripts/build.sh
 include requirements/build_requirements.txt
 include VERSION.txt
+include LICENSE.txt

--- a/scripts/test_building_from_source_distribution.sh
+++ b/scripts/test_building_from_source_distribution.sh
@@ -42,6 +42,10 @@ if [[ "${SOURCE_DISTRIBUTION_CONTENTS}" != "${BUILT_SOURCE_DISTRIBUTION_CONTENTS
     exit 1
 fi
 
-# Test the wheel that was built using the source distribution.
+# Test the contents of the wheel that was built using the source distribution to the contents of the
+# wheel built from the repository.
+WHEEL="${DISTRIBUTION_DIRECTORY}/seligimus-${VERSION}-py3-none-any.whl"
 BUILT_WHEEL="${EXTRACTED_SOURCE_DIRECTORY}/dist/seligimus-${VERSION}-py3-none-any.whl"
-"${SELIGIMUS}/scripts/test_wheel.sh" --wheel "${BUILT_WHEEL}"
+
+# diff -y <(unzip -l "${WHEEL}") <(unzip -l "${BUILT_WHEEL}")
+zipcmp "${WHEEL}" "${BUILT_WHEEL}"

--- a/scripts/test_source_distribution_contents.sh
+++ b/scripts/test_source_distribution_contents.sh
@@ -40,6 +40,9 @@ expected_contents+=$'\nREADME.md'
 # Add the version file to the list of expected contents.
 expected_contents+=$'\nVERSION.txt'
 
+# Add the license file to the list of expected contents.
+expected_contents+=$'\nLICENSE.txt'
+
 # Add files used for building distributions to the list of expected contents.
 expected_contents+=$'\nscripts/build.sh'
 expected_contents+=$'\nrequirements/build_requirements.txt'


### PR DESCRIPTION
Change the method for testing the wheel. Instead of running the Python
tests on it, just check that it has the same contents as the wheel built
from source.

Since the wheel build from source is tested with the pytests, this is
still checked. Also, it makes sure that the two wheels match.