### PR TITLE
Remove pushd with trapped popd

### DIFF
--- a/scripts/all.sh
+++ b/scripts/all.sh
@@ -4,8 +4,7 @@ set -eu
 
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-pushd "${HERE}" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${HERE}"
 
 ./format.sh
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,8 +5,7 @@ set -eu
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 SELIGIMUS="$(realpath "${HERE}/..")"
 
-pushd "${SELIGIMUS}" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
 use_venv distribution_building build_requirements.txt

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -5,7 +5,6 @@ set -eu
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 SELIGIMUS="$(realpath "${HERE}/..")"
 
-pushd "${SELIGIMUS}" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${SELIGIMUS}"
 
 python3 -m pytest --cov=seligimus --cov-report term-missing

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -5,8 +5,7 @@ set -eu
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 SELIGIMUS="$(realpath "${HERE}/..")"
 
-pushd "${SELIGIMUS}" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${SELIGIMUS}"
 
 python3 -m yapf -i -r .
 python3 -m isort .

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,7 +5,6 @@ set -eu
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 SELIGIMUS="$(realpath "${HERE}/..")"
 
-pushd "${SELIGIMUS}" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${SELIGIMUS}"
 
 find . \( -path ./venvs -o -path ./build \) -prune -false -o -name "*.py" | xargs python3 -m pylint

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,6 @@ set -eu
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 SELIGIMUS="$(realpath "${HERE}/..")"
 
-pushd "${SELIGIMUS}" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${SELIGIMUS}"
 
 python3 -m pytest

--- a/scripts/test_wheel.sh
+++ b/scripts/test_wheel.sh
@@ -72,8 +72,7 @@ python3 -m pip install ${WHEEL_FILE}
 # Go to the tests directory. Note that if we went to the root Seligimus directory then the the code 
 # would be used in testing instead of installed wheel (and we wouldn't actually be testing the
 # wheel).
-pushd "${SELIGIMUS}/tests" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${SELIGIMUS}/tests"
 
 # Verify that the installed Seligmus is being used when running Python.
 SELIGIMUS_PATH=$(python3 -c 'from pathlib import Path; import seligimus; print(Path(seligimus.__file__).parent)')

--- a/scripts/type_check.sh
+++ b/scripts/type_check.sh
@@ -5,7 +5,6 @@ set -eu
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 SELIGIMUS="$(realpath "${HERE}/..")"
 
-pushd "${SELIGIMUS}" > /dev/null
-trap "popd > /dev/null" EXIT
+cd "${SELIGIMUS}"
 
 python3 -m mypy


### PR DESCRIPTION
Remove the use of pushd with a trapped popd on exit. Replace usages
with just cd. Sense we never source the scripts, just using cd is fine.