### PR TITLE
Remove Python dep install from distribution action

### DIFF
--- a/.github/workflows/distributions.yml
+++ b/.github/workflows/distributions.yml
@@ -19,10 +19,6 @@ jobs:
       run: |
         sudo apt-get install zipcmp
 
-    - name: Install Python dependencies
-      run: |
-        python3 -m pip install -r requirements/build_requirements.txt
-
     - name: Build a Python source distrubution and wheel
       run: |
         ./scripts/build.sh


### PR DESCRIPTION
Remove the installation of Python dependencies from the distribution
action because the scripts handle their own dependencies.