### PR TITLE
Add venv usage to scripts

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -15,11 +15,6 @@ jobs:
       with:
         python-version: 3.6
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip setuptools wheel
-        python3 -m pip install -r requirements/test_requirements.txt
-
     - name: Test with pytest
       run: |
         ./scripts/coverage.sh

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -7,4 +7,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 
 cd "${SELIGIMUS}"
 
+source "${SELIGIMUS}/scripts/library/venv.sh"
+use_venv "test" test_requirements.txt
+
 python3 -m pytest --cov=seligimus --cov-report term-missing

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,5 +7,8 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 
 cd "${SELIGIMUS}"
 
+source "${SELIGIMUS}/scripts/library/venv.sh"
+use_venv developer developer_requirements.txt
+
 python3 -m yapf -i -r .
 python3 -m isort .

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,4 +7,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 
 cd "${SELIGIMUS}"
 
+source "${SELIGIMUS}/scripts/library/venv.sh"
+use_venv "test" test_requirements.txt
+
 find . \( -path ./venvs -o -path ./build \) -prune -false -o -name "*.py" | xargs python3 -m pylint

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,4 +7,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 
 cd "${SELIGIMUS}"
 
+source "${SELIGIMUS}/scripts/library/venv.sh"
+use_venv "test" test_requirements.txt
+
 python3 -m pytest

--- a/scripts/type_check.sh
+++ b/scripts/type_check.sh
@@ -7,4 +7,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 
 cd "${SELIGIMUS}"
 
+source "${SELIGIMUS}/scripts/library/venv.sh"
+use_venv "test" test_requirements.txt
+
 python3 -m mypy


### PR DESCRIPTION
Add virtual environment usage to scripts that were not using them. This
adds a lot of time, but I don't think it will be bad after making venvs
reusable. We also might want to consider combining the developer and
test venvs/requirements so that only one venv is needed for the all
script.