### PR TITLE
Add PyPI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Seligimus
+[![PyPI version](https://badge.fury.io/py/seligimus.svg)](https://badge.fury.io/py/seligimus)
 
 A mono-library.
 


### PR DESCRIPTION
Add a badge to the `README.md` files with information about the PyPI
package.