### PR TITLE
Ascola/reuse virtual environments

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include scripts/build.sh
 include scripts/library/venv.sh
 include requirements/basic_requirements.txt
-include requirements/build_requirements.txt
+include requirements/frozen/frozen_build_requirements.txt
 include VERSION.txt
 include LICENSE.txt

--- a/requirements/basic_requirements.txt
+++ b/requirements/basic_requirements.txt
@@ -1,2 +1,3 @@
 pip==21.0.1
 setuptools==52.0.0
+wheel==0.36.2

--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -1,1 +1,0 @@
-setuptools==52.0.0

--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -1,2 +1,1 @@
 setuptools==52.0.0
-wheel==0.36.2

--- a/requirements/frozen/frozen_basic_requirements.txt
+++ b/requirements/frozen/frozen_basic_requirements.txt
@@ -1,1 +1,1 @@
-pkg-resources==0.0.0
+

--- a/requirements/frozen/frozen_build_requirements.txt
+++ b/requirements/frozen/frozen_build_requirements.txt
@@ -1,1 +1,1 @@
-pkg-resources==0.0.0
+

--- a/requirements/frozen/frozen_deployment_requirements.txt
+++ b/requirements/frozen/frozen_deployment_requirements.txt
@@ -10,7 +10,6 @@ importlib-metadata==3.4.0
 jeepney==0.6.0
 keyring==22.0.1
 packaging==20.9
-pkg-resources==0.0.0
 pkginfo==1.7.0
 pycparser==2.20
 Pygments==2.7.4

--- a/requirements/frozen/frozen_developer_requirements.txt
+++ b/requirements/frozen/frozen_developer_requirements.txt
@@ -1,7 +1,6 @@
 isort==5.7.0
 mypy==0.790
 mypy-extensions==0.4.3
-pkg-resources==0.0.0
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
 yapf==0.30.0

--- a/requirements/frozen/frozen_test_requirements.txt
+++ b/requirements/frozen/frozen_test_requirements.txt
@@ -9,7 +9,6 @@ mccabe==0.6.1
 mypy==0.790
 mypy-extensions==0.4.3
 packaging==20.9
-pkg-resources==0.0.0
 pluggy==0.13.1
 py==1.10.0
 pylint==2.6.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements distribution_building frozen_build_requirements.txt
+use_venv distribution_building frozen_build_requirements.txt
 
 python3 setup.py sdist bdist_wheel
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv distribution_building build_requirements.txt
+use_clean_venv distribution_building build_requirements.txt
 
 python3 setup.py sdist bdist_wheel
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv distribution_building build_requirements.txt
+use_clean_venv_from_frozen_requirements distribution_building frozen_build_requirements.txt
 
 python3 setup.py sdist bdist_wheel
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv "test" test_requirements.txt
+use_clean_venv "test" test_requirements.txt
 
 python3 -m pytest --cov=seligimus --cov-report term-missing

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
+use_venv "test" frozen_test_requirements.txt
 
 python3 -m pytest --cov=seligimus --cov-report term-missing

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv "test" test_requirements.txt
+use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
 
 python3 -m pytest --cov=seligimus --cov-report term-missing

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,7 +8,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements developer frozen_developer_requirements.txt
+use_venv developer frozen_developer_requirements.txt
 
 python3 -m yapf -i -r .
 python3 -m isort .

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,7 +8,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv developer developer_requirements.txt
+use_clean_venv_from_frozen_requirements developer frozen_developer_requirements.txt
 
 python3 -m yapf -i -r .
 python3 -m isort .

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,7 +8,7 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv developer developer_requirements.txt
+use_clean_venv developer developer_requirements.txt
 
 python3 -m yapf -i -r .
 python3 -m isort .

--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -19,7 +19,7 @@ function freeze_requirements() {
     local REQUIREMENTS_FILE="$(basename "${REQUIREMENTS_FILE_PATH}")"
     use_clean_venv "${VENV_NAME}" "${REQUIREMENTS_FILE}"
 
-    local FROZEN_REQUIREMENTS="$(pip freeze)"
+    local FROZEN_REQUIREMENTS="$(pip freeze | sed '/pkg-resources/d')"
 
     set +u
     deactivate

--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -19,7 +19,7 @@ function freeze_requirements() {
     local REQUIREMENTS_FILE="$(basename "${REQUIREMENTS_FILE_PATH}")"
     use_clean_venv "${VENV_NAME}" "${REQUIREMENTS_FILE}"
 
-    local FROZEN_REQUIREMENTS="$(pip freeze | sed '/pkg-resources/d')"
+    local FROZEN_REQUIREMENTS="$(get_frozen_requirements)"
 
     deactivate_venv
 

--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -17,7 +17,7 @@ function freeze_requirements() {
     echo "Using virtual environment name '${VENV_NAME}'."
 
     local REQUIREMENTS_FILE="$(basename "${REQUIREMENTS_FILE_PATH}")"
-    use_venv "${VENV_NAME}" "${REQUIREMENTS_FILE}"
+    use_clean_venv "${VENV_NAME}" "${REQUIREMENTS_FILE}"
 
     local FROZEN_REQUIREMENTS="$(pip freeze)"
 

--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -21,9 +21,7 @@ function freeze_requirements() {
 
     local FROZEN_REQUIREMENTS="$(pip freeze | sed '/pkg-resources/d')"
 
-    set +u
-    deactivate
-    set -u
+    deactivate_venv
 
     FROZEN_REQUIREMENTS_FILE_NAME="frozen_${REQUIREMENTS_FILE}"
     FROZEN_REQUIREMENTS_FILE_PATH="${FROZEN_REQUIREMENTS_DIRECTORY}/${FROZEN_REQUIREMENTS_FILE_NAME}"

--- a/scripts/library/venv.sh
+++ b/scripts/library/venv.sh
@@ -22,6 +22,12 @@ function _activate_venv() {
     source "${VENV_PATH}/bin/activate"
 }
 
+function deactivate_venv() {
+    set +u
+    deactivate
+    set -u
+}
+
 function _install_requirements() {
     local REQUIREMENTS_FILE_NAME="$1"
     local REQUIREMENTS_FILE_PATH="${SELIGIMUS}/requirements/${REQUIREMENTS_FILE_NAME}"
@@ -55,9 +61,7 @@ function requirements_match() {
 
     _activate_venv "${VENV_PATH}"
     local ACTUAL_FROZEN_REQUIREMENTS="$(pip freeze | sed '/pkg-resources/d')"
-    set +u
-    deactivate
-    set -u
+    deactivate_venv
 
     local FROZEN_REQUIREMENTS_FILE_PATH="${SELIGIMUS}/requirements/frozen/${FROZEN_REQUIREMENTS_FILE_NAME}"
     local EXPECTED_FROZEN_REQUIREMENTS="$(cat "${FROZEN_REQUIREMENTS_FILE_PATH}")"

--- a/scripts/library/venv.sh
+++ b/scripts/library/venv.sh
@@ -12,14 +12,14 @@ function _activate_venv() {
 }
 
 function _install_requirements() {
-    local REQUIREMENTS_FILE="$1"
-    local REQUIREMENTS_PATH="${SELIGIMUS}/requirements/${REQUIREMENTS_FILE}"
-    python3 -m pip install -r "${REQUIREMENTS_PATH}"
+    local REQUIREMENTS_FILE_NAME="$1"
+    local REQUIREMENTS_FILE_PATH="${SELIGIMUS}/requirements/${REQUIREMENTS_FILE_NAME}"
+    python3 -m pip install -r "${REQUIREMENTS_FILE_PATH}"
 }
 
 function get_venv_name_from_requirements_file() {
-    local REQUIREMENTS_FILE="$1"
-    local REQUIREMENTS_FILE_NAME="$(basename "${REQUIREMENTS_FILE}")"
+    local REQUIREMENTS_FILE_PATH="$1"
+    local REQUIREMENTS_FILE_NAME="$(basename "${REQUIREMENTS_FILE_PATH}")"
     local VENV_NAME="$( echo "${REQUIREMENTS_FILE_NAME}" | cut --delimiter=_ --fields=1)"
     echo "${VENV_NAME}"
 }
@@ -32,12 +32,12 @@ function get_venv_path() {
 
 function use_clean_venv() {
     local VENV_NAME="$1"
-    local REQUIREMENTS_FILE="$2"
+    local REQUIREMENTS_FILE_NAME="$2"
 
     local VENV_PATH="$(get_venv_path "${VENV_NAME}")"
 
     _make_venv "${VENV_PATH}"
     _activate_venv "${VENV_PATH}"
     _install_requirements "basic_requirements.txt"
-    _install_requirements "${REQUIREMENTS_FILE}"
+    _install_requirements "${REQUIREMENTS_FILE_NAME}"
 }

--- a/scripts/library/venv.sh
+++ b/scripts/library/venv.sh
@@ -53,6 +53,11 @@ function get_venv_path() {
     echo "${VENV_PATH}"
 }
 
+function get_frozen_requirements() {
+    local FROZEN_REQUIREMENTS="$(pip freeze | sed '/pkg-resources/d')"
+    echo "${FROZEN_REQUIREMENTS}"
+}
+
 function requirements_match() {
     local VENV_NAME="$1"
     local FROZEN_REQUIREMENTS_FILE_NAME="$2"
@@ -60,7 +65,7 @@ function requirements_match() {
     local VENV_PATH="$(get_venv_path "${VENV_NAME}")"
 
     _activate_venv "${VENV_PATH}"
-    local ACTUAL_FROZEN_REQUIREMENTS="$(pip freeze | sed '/pkg-resources/d')"
+    local ACTUAL_FROZEN_REQUIREMENTS="$(get_frozen_requirements)"
     deactivate_venv
 
     local FROZEN_REQUIREMENTS_FILE_PATH="${SELIGIMUS}/requirements/frozen/${FROZEN_REQUIREMENTS_FILE_NAME}"

--- a/scripts/library/venv.sh
+++ b/scripts/library/venv.sh
@@ -17,6 +17,12 @@ function _install_requirements() {
     python3 -m pip install -r "${REQUIREMENTS_FILE_PATH}"
 }
 
+function _install_frozen_requirements() {
+    local FROZEN_REQUIREMENTS_FILE_NAME="$1"
+    local FROZEN_REQUIREMENTS_FILE_PATH="${SELIGIMUS}/requirements/frozen/${FROZEN_REQUIREMENTS_FILE_NAME}"
+    python3 -m pip install -r "${FROZEN_REQUIREMENTS_FILE_PATH}"
+}
+
 function get_venv_name_from_requirements_file() {
     local REQUIREMENTS_FILE_PATH="$1"
     local REQUIREMENTS_FILE_NAME="$(basename "${REQUIREMENTS_FILE_PATH}")"
@@ -40,4 +46,16 @@ function use_clean_venv() {
     _activate_venv "${VENV_PATH}"
     _install_requirements "basic_requirements.txt"
     _install_requirements "${REQUIREMENTS_FILE_NAME}"
+}
+
+function use_clean_venv_from_frozen_requirements() {
+    local VENV_NAME="$1"
+    local FROZEN_REQUIREMENTS_FILE_NAME="$2"
+
+    local VENV_PATH="$(get_venv_path "${VENV_NAME}")"
+
+    _make_venv "${VENV_PATH}"
+    _activate_venv "${VENV_PATH}"
+    _install_requirements "basic_requirements.txt"
+    _install_frozen_requirements "${FROZEN_REQUIREMENTS_FILE_NAME}"
 }

--- a/scripts/library/venv.sh
+++ b/scripts/library/venv.sh
@@ -30,7 +30,7 @@ function get_venv_path() {
     echo "${VENV_PATH}"
 }
 
-function use_venv() {
+function use_clean_venv() {
     local VENV_NAME="$1"
     local REQUIREMENTS_FILE="$2"
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv "test" test_requirements.txt
+use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
 
 find . \( -path ./venvs -o -path ./build \) -prune -false -o -name "*.py" | xargs python3 -m pylint

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
+use_venv "test" frozen_test_requirements.txt
 
 find . \( -path ./venvs -o -path ./build \) -prune -false -o -name "*.py" | xargs python3 -m pylint

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv "test" test_requirements.txt
+use_clean_venv "test" test_requirements.txt
 
 find . \( -path ./venvs -o -path ./build \) -prune -false -o -name "*.py" | xargs python3 -m pylint

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -21,7 +21,7 @@ fi
 set -u
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv deployment deployment_requirements.txt
+use_clean_venv deployment deployment_requirements.txt
 
 python3 -m twine upload \
     --non-interactive \

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -21,7 +21,7 @@ fi
 set -u
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv deployment deployment_requirements.txt
+use_clean_venv_from_frozen_requirements deployment frozen_deployment_requirements.txt
 
 python3 -m twine upload \
     --non-interactive \

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -21,7 +21,7 @@ fi
 set -u
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements deployment frozen_deployment_requirements.txt
+use_venv deployment frozen_deployment_requirements.txt
 
 python3 -m twine upload \
     --non-interactive \

--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -21,7 +21,7 @@ fi
 set -u
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv deployment deployment_requirements.txt
+use_clean_venv_from_frozen_requirements deployment frozen_deployment_requirements.txt
 
 python3 -m twine upload \
     --repository testpypi \

--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -21,7 +21,7 @@ fi
 set -u
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements deployment frozen_deployment_requirements.txt
+use_venv deployment frozen_deployment_requirements.txt
 
 python3 -m twine upload \
     --repository testpypi \

--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -21,7 +21,7 @@ fi
 set -u
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv deployment deployment_requirements.txt
+use_clean_venv deployment deployment_requirements.txt
 
 python3 -m twine upload \
     --repository testpypi \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv "test" test_requirements.txt
+use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
 
 python3 -m pytest

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
+use_venv "test" frozen_test_requirements.txt
 
 python3 -m pytest

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv "test" test_requirements.txt
+use_clean_venv "test" test_requirements.txt
 
 python3 -m pytest

--- a/scripts/test_source_distribution_contents.sh
+++ b/scripts/test_source_distribution_contents.sh
@@ -47,7 +47,7 @@ expected_contents+=$'\nLICENSE.txt'
 expected_contents+=$'\nscripts/build.sh'
 expected_contents+=$'\nscripts/library/venv.sh'
 expected_contents+=$'\nrequirements/basic_requirements.txt'
-expected_contents+=$'\nrequirements/build_requirements.txt'
+expected_contents+=$'\nrequirements/frozen/frozen_build_requirements.txt'
 expected_contents+=$'\nsetup.py'
 expected_contents+=$'\nsetup.cfg'
 

--- a/scripts/test_wheel.sh
+++ b/scripts/test_wheel.sh
@@ -66,7 +66,7 @@ fi
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
 VENV_NAME=wheel_testing
-use_venv "${VENV_NAME}" test_requirements.txt
+use_clean_venv "${VENV_NAME}" test_requirements.txt
 
 # Install the wheel in the virtual environment.
 python3 -m pip install ${WHEEL_FILE}

--- a/scripts/test_wheel.sh
+++ b/scripts/test_wheel.sh
@@ -66,7 +66,7 @@ fi
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
 VENV_NAME=wheel_testing
-use_clean_venv "${VENV_NAME}" test_requirements.txt
+use_clean_venv_from_frozen_requirements "${VENV_NAME}" frozen_test_requirements.txt
 
 # Install the wheel in the virtual environment.
 python3 -m pip install ${WHEEL_FILE}

--- a/scripts/type_check.sh
+++ b/scripts/type_check.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_venv "test" test_requirements.txt
+use_clean_venv "test" test_requirements.txt
 
 python3 -m mypy

--- a/scripts/type_check.sh
+++ b/scripts/type_check.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv "test" test_requirements.txt
+use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
 
 python3 -m mypy

--- a/scripts/type_check.sh
+++ b/scripts/type_check.sh
@@ -8,6 +8,6 @@ SELIGIMUS="$(realpath "${HERE}/..")"
 cd "${SELIGIMUS}"
 
 source "${SELIGIMUS}/scripts/library/venv.sh"
-use_clean_venv_from_frozen_requirements "test" frozen_test_requirements.txt
+use_venv "test" frozen_test_requirements.txt
 
 python3 -m mypy


### PR DESCRIPTION
Change virtual environments to be reused if the virtual environment is
already set up with the same frozen requirements. The only venv not
reused by default is the wheel testing venv because it installs the
package and so it is a bit trickier to do intelligently.