### PR TITLE
Fix package imports to work with mypy

### DIFF
--- a/scripts/test_source_distribution_contents.sh
+++ b/scripts/test_source_distribution_contents.sh
@@ -30,9 +30,12 @@ contents=$(echo "${contents}" | sort -t "/")
 # Create a list of the files expected to be in the source distribution.
 expected_contents=""
 
+# Add the file which tells mypy that the Python files have inline type annotations.
+expected_contents+="seligimus/py.typed"
+
 # Add the Python files in the seligimus package to the list of expected contents.
 PYTHON_FILES="$(find "${SELIGIMUS}/seligimus" -type f -name "*.py" -printf "seligimus/%P\n")"
-expected_contents+="${PYTHON_FILES}"
+expected_contents+="${NEWLINE}${PYTHON_FILES}"
 
 # Add the readme to the list of expected contents.
 expected_contents+=$'\nREADME.md'
@@ -56,6 +59,7 @@ expected_contents+=$'\nseligimus.egg-info/dependency_links.txt'
 expected_contents+=$'\nseligimus.egg-info/PKG-INFO'
 expected_contents+=$'\nseligimus.egg-info/SOURCES.txt'
 expected_contents+=$'\nseligimus.egg-info/top_level.txt'
+expected_contents+=$'\nseligimus.egg-info/not-zip-safe'
 
 # Add the manifest to the list of expected contents.
 expected_contents+=$'\nMANIFEST.in'

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/pypa/sampleproject',
     packages=_PACKAGES,
+    package_data={'seligimus': ['py.typed']},
+    zip_safe=False,
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Fix type checking a Seligimus import by telling mypy that the package
contains inline type annotations.