### PR TITLE
Add standard repr name mapping

### DIFF
--- a/seligimus/python/decorators/standard_representation.py
+++ b/seligimus/python/decorators/standard_representation.py
@@ -1,15 +1,23 @@
 """A decorator for the repr dunder to return a standard representation."""
 from inspect import Parameter
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from seligimus.python.functions.parameter_kind import ParameterKind
 from seligimus.python.functions.parameter_list import ParameterList
 from seligimus.python.functions.parameters import get_parameters_by_kind
 
 
-def standard_representation(representation_function: Callable[[Any], str]) -> Callable[[Any], str]:
+def standard_representation(
+        representation_function: Callable[[Any], str],
+        parameter_to_attribute_name: Optional[Dict[str, str]] = None) -> Callable[[Any], str]:
     """Return an repr which returns return a standard representation."""
     del representation_function
+
+    _parameter_to_attribute_name: Dict[str, str]
+    if parameter_to_attribute_name is None:
+        _parameter_to_attribute_name = {}
+    else:
+        _parameter_to_attribute_name = parameter_to_attribute_name
 
     def standard_representation_function(self: Any) -> str:
         class_name: str = self.__class__.__name__
@@ -27,7 +35,8 @@ def standard_representation(representation_function: Callable[[Any], str]) -> Ca
             if parameter_name == 'self':
                 continue
 
-            parameter_value: Any = getattr(self, parameter_name)
+            attribute_name: str = _parameter_to_attribute_name.get(parameter_name, parameter_name)
+            parameter_value = getattr(self, attribute_name)
             parameter_default_value: Any = initialization_positional_parameter.default
 
             parameter_representation: str

--- a/tests/python/decorators/test_standard_representation.py
+++ b/tests/python/decorators/test_standard_representation.py
@@ -29,16 +29,19 @@ def init_5(self: Any, bar: int, baz: str = 'spam') -> None:  # pylint: disable=m
 
 
 # yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('class_name, initialization_method, instance_attributes, expected_representation', [
-    ('Foo', init_1, {}, 'Foo()'),
-    ('Foo', init_2, {'bar': 1}, 'Foo(1)'),
-    ('Foo', init_3, {'bar': 1, 'baz': 'spam'}, "Foo(1, 'spam')"),
-    ('Foo', init_4, {'bar': 1}, 'Foo(bar=1)'),
-    ('Foo', init_5, {'bar': 1, 'baz': 'spam'}, 'Foo(1)'),
+@pytest.mark.parametrize('class_name, initialization_method, instance_attributes, parameter_to_attribute_name, expected_representation', [
+    ('Foo', init_1, {}, None, 'Foo()'),
+    ('Foo', init_2, {'bar': 1}, None, 'Foo(1)'),
+    ('Foo', init_2, {'baz': 1}, {'bar': 'baz'}, 'Foo(1)'),
+    ('Foo', init_3, {'bar': 1, 'baz': 'spam'}, None, "Foo(1, 'spam')"),
+    ('Foo', init_4, {'bar': 1}, None, 'Foo(bar=1)'),
+    ('Foo', init_4, {'wibble': 1}, {'bar': 'wibble'}, 'Foo(bar=1)'),
+    ('Foo', init_5, {'bar': 1, 'baz': 'spam'}, None, 'Foo(1)'),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_standard_reprsentation(class_name: str, initialization_method: Callable[[], None],
                                 instance_attributes: Dict[str, Any],
+                                parameter_to_attribute_name: Dict[str, str],
                                 expected_representation: str) -> None:
     """Test seligimus.python.decorators.standard_representation."""
     class_ = types.new_class(class_name)
@@ -46,7 +49,9 @@ def test_standard_reprsentation(class_name: str, initialization_method: Callable
     instance.__init__ = initialization_method
     set_attributes(instance, instance_attributes)
 
-    representation_function: Callable[[Any], str] = standard_representation(instance.__repr__)
+    representation_function: Callable[[Any],
+                                      str] = standard_representation(instance.__repr__,
+                                                                     parameter_to_attribute_name)
 
     representation = representation_function(instance)
 


### PR DESCRIPTION
Add an argument to the standard representation for mapping parameter
names to instance attribute names. This is helpful if an initialization
argument name doesn't match the name of the instance attribute that it
is assigned to. For example if the instance attribute is private as
denoted by a leading underscore.