### PR TITLE
Add string drop

### DIFF
--- a/seligimus/strings/drop.py
+++ b/seligimus/strings/drop.py
@@ -1,0 +1,6 @@
+"""The characters of a string without the first character."""
+
+
+def drop(string: str) -> str:
+    """Return a string without the first character."""
+    return string[1:]

--- a/tests/strings/test_drop.py
+++ b/tests/strings/test_drop.py
@@ -1,0 +1,18 @@
+"""Test seligimus.strings.drop."""
+import pytest
+
+from seligimus.strings.drop import drop
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('string, expected_body', [
+    ('', ''),
+    ('a', ''),
+    ('abc', 'bc'),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_drop(string: str, expected_body: str) -> None:
+    """Test seligimus.strings.drop.drop."""
+    body: str = drop(string)
+
+    assert body == expected_body


### PR DESCRIPTION
Add a method for returning a string without the first character. Id est,
the first character is "dropped".

It might make sense to generalize this to other types eventually. And
also to a different number of drops.