### PR TITLE
Fix type of sum of two 2D integer positions

### DIFF
--- a/seligimus/maths/integer_position_2d.py
+++ b/seligimus/maths/integer_position_2d.py
@@ -1,4 +1,6 @@
 """A position in the two-dimensional integer lattice."""
+from typing import overload
+
 from seligimus.maths.vector_2 import Vector2
 
 
@@ -6,3 +8,16 @@ class IntegerPosition2D(Vector2[int]):  # pylint: disable=too-few-public-methods
     """A position in the two-dimensional integer lattice."""
     def __init__(self, x: int = 0, y: int = 0):  # pylint: disable=invalid-name, useless-super-delegation
         super().__init__(x, y)
+
+    @overload
+    def __add__(self, other: 'IntegerPosition2D') -> 'IntegerPosition2D':
+        ...  # pragma: no cover
+
+    @overload
+    def __add__(self, other: Vector2[int]) -> 'IntegerPosition2D':
+        ...  # pragma: no cover
+
+    def __add__(self, other: Vector2) -> Vector2:
+        sum_: Vector2[int] = super().__add__(other)
+
+        return IntegerPosition2D(sum_.x, sum_.y)

--- a/tests/maths/test_integer_position_2d.py
+++ b/tests/maths/test_integer_position_2d.py
@@ -58,3 +58,16 @@ def test_init(x: Optional[int], pass_x_as_argument: bool, pass_x_as_keyword_argu
 
     assert integer_position_2d.x == expected_x
     assert integer_position_2d.y == expected_y
+
+
+# yapf: disable
+@pytest.mark.parametrize('integer_position_2d, other, expected_sum', [
+    (IntegerPosition2D(0, 0), IntegerPosition2D(0, 0), IntegerPosition2D(0, 0)),
+])
+# yapf: enable
+def test_add(integer_position_2d: IntegerPosition2D, other: IntegerPosition2D,
+             expected_sum: IntegerPosition2D) -> None:
+    """Test seligimus.maths.integer_position_2d.IntegerPosition2D.__add__."""
+    sum_: IntegerPosition2D = integer_position_2d + other
+
+    assert sum_ == expected_sum


### PR DESCRIPTION
Fix the type of the sum of two 2D integer positions to also be a 2D
integer position.

There is some room for cleanup here and there are probably some other
oddities introduced by this, but it does fix the bug of sum having the
wrong type.