### PR TITLE
Add isorted files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ venvs/*
 # Ignore mypy cache.
 .mypy_cache
 
+# Ignore temporary files used by isort.
+.isorted
+
 # Ignore test coverage.
 .coverage
 


### PR DESCRIPTION
Add a rule to the `.gitignore` to ignore temporary files used by isort.