### PR TITLE
Ascola/refactor standard equality usage

### DIFF
--- a/seligimus/maths/vector_2.py
+++ b/seligimus/maths/vector_2.py
@@ -1,5 +1,5 @@
 """A two-dimensional vector."""
-from typing import Any, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from seligimus.python.decorators.operators.equality.standard_equality import standard_equality
 from seligimus.python.decorators.standard_representation import standard_representation
@@ -13,9 +13,7 @@ class Vector2(Generic[T]):
         self.x: T = x  # pylint: disable=invalid-name
         self.y: T = y  # pylint: disable=invalid-name
 
-    @standard_equality
-    def __eq__(self, other: Any) -> bool:
-        pass  # pragma: no cover
+    __eq__ = standard_equality()
 
     def __bool__(self) -> bool:
         return bool(self.x) or bool(self.y)

--- a/seligimus/python/decorators/operators/equality/standard_equality.py
+++ b/seligimus/python/decorators/operators/equality/standard_equality.py
@@ -1,12 +1,14 @@
 """A decorator for equality operators to check that the other object has the same type and the same
 instance attributes."""
+from typing import Optional
+
 from seligimus.python.decorators.operators.equality.equal_instance_attributes import \
     equal_instance_attributes
 from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from seligimus.python.decorators.operators.equality.equality_operator import EqualityOperator
 
 
-def standard_equality(_equality_operator: EqualityOperator) -> EqualityOperator:
+def standard_equality(_equality_operator: Optional[EqualityOperator] = None) -> EqualityOperator:
     """A decorator for equality operators to check that the other object has the same type and the
     same instance attributes."""
     standard_equality_operator = equal_type(equal_instance_attributes(lambda self, other: True))

--- a/tests/python/decorators/operators/equality/test_standard_equality.py
+++ b/tests/python/decorators/operators/equality/test_standard_equality.py
@@ -1,5 +1,5 @@
 """Test seligimus.python.decorators.operators.equality.standard_equality."""
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -10,6 +10,10 @@ from seligimus.python.decorators.operators.equality.standard_equality import sta
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('equality_operator, self_class_name, other_class_name, self_attributes, other_attributes, expected_equality', [
+    (None, 'Foo', 'Bar', {}, {}, False),
+    (None, 'Foo', 'Foo', {'spam': 1}, {}, False),
+    (None, 'Foo', 'Foo', {}, {}, True),
+    (None, 'Foo', 'Foo', {'spam': 1}, {'spam': 1}, True),
     (lambda self, other: None, 'Foo', 'Bar', {}, {}, False),
     (lambda self, other: None, 'Foo', 'Foo', {'spam': 1}, {}, False),
     (lambda self, other: None, 'Foo', 'Foo', {}, {}, True),
@@ -17,7 +21,7 @@ from seligimus.python.decorators.operators.equality.standard_equality import sta
 ])
 # yapf: enable # pylint: enable=line-too-long
 # pylint: disable=too-many-arguments
-def test_standard_equality(equality_operator: EqualityOperator, self_class_name: str,
+def test_standard_equality(equality_operator: Optional[EqualityOperator], self_class_name: str,
                            other_class_name: str, self_attributes: Dict[str, Any],
                            other_attributes: Dict[str, Any], expected_equality: bool) -> None:
     """Test seligimus.python.decorators.operators.equality.standard_equality.standard_equality."""


### PR DESCRIPTION
Change the way the standard equality decorator is used. While this is
less characters, I'm not sure if is to magical?