### PR TITLE
Ascola/add recursive representations

### DIFF
--- a/seligimus/python/decorators/standard_representation.py
+++ b/seligimus/python/decorators/standard_representation.py
@@ -45,20 +45,20 @@ def standard_representation(
         def standard_representation_function(self: Any) -> str:
             class_name: str = self.__class__.__name__
 
-            initialiazation_parameters_by_kind: Dict[ParameterKind, ParameterList] = \
-                get_parameters_by_kind( self.__init__)
+            parameters_by_kind: Dict[ParameterKind, ParameterList] = \
+                get_parameters_by_kind(self.__init__)
 
-            initialization_positional_parameters: ParameterList = \
-                initialiazation_parameters_by_kind[ParameterKind.POSITIONAL_OR_KEYWORD]
+            positional_parameters: ParameterList = \
+                parameters_by_kind[ParameterKind.POSITIONAL_OR_KEYWORD]
 
-            initialization_arguments: List[str] = []
-            for initialization_positional_parameter in initialization_positional_parameters:
-                parameter_name: str = initialization_positional_parameter.name
+            arguments: List[str] = []
+            for positional_parameter in positional_parameters:
+                parameter_name: str = positional_parameter.name
 
                 attribute_name: str = _parameter_to_attribute_name.get(
                     parameter_name, parameter_name)
                 parameter_value = getattr(self, attribute_name)
-                parameter_default_value: Any = initialization_positional_parameter.default
+                parameter_default_value: Any = positional_parameter.default
 
                 parameter_representation: str
                 if parameter_default_value == Parameter.empty:
@@ -68,11 +68,11 @@ def standard_representation(
                 else:
                     continue  # pragma: no cover (https://github.com/nedbat/coveragepy/issues/198)
 
-                initialization_arguments.append(parameter_representation)
+                arguments.append(parameter_representation)
 
-            initialization_arguments_string: str = ', '.join(initialization_arguments)
+            arguments_string: str = ', '.join(arguments)
 
-            return f'{class_name}({initialization_arguments_string})'
+            return f'{class_name}({arguments_string})'
 
         return standard_representation_function
 

--- a/seligimus/python/decorators/standard_representation.py
+++ b/seligimus/python/decorators/standard_representation.py
@@ -54,8 +54,6 @@ def standard_representation(
             initialization_arguments: List[str] = []
             for initialization_positional_parameter in initialization_positional_parameters:
                 parameter_name: str = initialization_positional_parameter.name
-                if parameter_name == 'self':
-                    continue
 
                 attribute_name: str = _parameter_to_attribute_name.get(
                     parameter_name, parameter_name)

--- a/tests/python/decorators/test_standard_representation.py
+++ b/tests/python/decorators/test_standard_representation.py
@@ -1,10 +1,8 @@
 """Test seligimus.python.decorators.standard_representation."""
-import types
 from typing import Any, Callable, Dict
 
 import pytest
 
-from seligimus.python.classes.attributes import set_attributes
 from seligimus.python.decorators.standard_representation import (Repr, ReprDecorator,
                                                                  standard_representation)
 
@@ -21,47 +19,63 @@ def test_repr_decorator() -> None:
     assert ReprDecorator.__args__ == (Repr, Repr)  # type: ignore[attr-defined]
 
 
-def init_1(self: Any) -> None:  # pylint: disable=missing-function-docstring, unused-argument
-    pass
+# pylint: disable=too-few-public-methods, missing-class-docstring, disallowed-name
 
 
-def init_2(self: Any, bar: int) -> None:  # pylint: disable=missing-function-docstring, blacklisted-name, unused-argument
-    pass
+class Foo1():
+    def __init__(self) -> None:
+        pass
 
 
-def init_3(self: Any, bar: int, baz: str) -> None:  # pylint: disable=missing-function-docstring, blacklisted-name, unused-argument
-    pass
+class Foo2():
+    def __init__(self, bar: int) -> None:
+        self.bar: int = bar
 
 
-def init_4(self: Any, bar: int = 0) -> None:  # pylint: disable=missing-function-docstring, blacklisted-name, unused-argument
-    pass
+class Foo2a():
+    def __init__(self, bar: int) -> None:
+        self.baz: int = bar
 
 
-def init_5(self: Any, bar: int, baz: str = 'spam') -> None:  # pylint: disable=missing-function-docstring, blacklisted-name, unused-argument
-    pass
+class Foo3():
+    def __init__(self, bar: int, baz: str) -> None:
+        self.bar: int = bar
+        self.baz: str = baz
 
 
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('class_name, initialization_method, instance_attributes, parameter_to_attribute_name, expected_representation', [
-    ('Foo', init_1, {}, None, 'Foo()'),
-    ('Foo', init_2, {'bar': 1}, None, 'Foo(1)'),
-    ('Foo', init_2, {'baz': 1}, {'bar': 'baz'}, 'Foo(1)'),
-    ('Foo', init_3, {'bar': 1, 'baz': 'spam'}, None, "Foo(1, 'spam')"),
-    ('Foo', init_4, {'bar': 1}, None, 'Foo(bar=1)'),
-    ('Foo', init_4, {'wibble': 1}, {'bar': 'wibble'}, 'Foo(bar=1)'),
-    ('Foo', init_5, {'bar': 1, 'baz': 'spam'}, None, 'Foo(1)'),
+class Foo4():
+    def __init__(self, bar: int = 0) -> None:
+        self.bar: int = bar
+
+
+class Foo4a():
+    def __init__(self, bar: int = 0) -> None:
+        self.wibble: int = bar
+
+
+class Foo5():
+    def __init__(self, bar: int, baz: str = 'spam') -> None:
+        self.bar: int = bar
+        self.baz: str = baz
+
+
+# pylint: enable=disallowed-name
+
+
+# yapf: disable
+@pytest.mark.parametrize('instance, parameter_to_attribute_name, expected_representation', [
+    (Foo1(), None, 'Foo1()'),
+    (Foo2(1), None, 'Foo2(1)'),
+    (Foo2a(1), {'bar': 'baz'}, 'Foo2a(1)'),
+    (Foo3(1, 'spam'), None, "Foo3(1, 'spam')"),
+    (Foo4(bar=1), None, 'Foo4(bar=1)'),
+    (Foo4a(1), {'bar': 'wibble'}, 'Foo4a(bar=1)'),
+    (Foo5(1), None, 'Foo5(1)'),
 ])
-# yapf: enable # pylint: enable=line-too-long
-def test_standard_reprsentation(class_name: str, initialization_method: Callable[[], None],
-                                instance_attributes: Dict[str, Any],
-                                parameter_to_attribute_name: Dict[str, str],
+# yapf: enable
+def test_standard_reprsentation(instance: Any, parameter_to_attribute_name: Dict[str, str],
                                 expected_representation: str) -> None:
     """Test seligimus.python.decorators.standard_representation."""
-    class_ = types.new_class(class_name)
-    instance = class_()
-    instance.__init__ = initialization_method
-    set_attributes(instance, instance_attributes)
-
     representation_function: Repr
     if parameter_to_attribute_name:
         representation_decorator: Callable[[Repr], Repr] = \

--- a/tests/python/decorators/test_standard_representation.py
+++ b/tests/python/decorators/test_standard_representation.py
@@ -1,5 +1,5 @@
 """Test seligimus.python.decorators.standard_representation."""
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 import pytest
 
@@ -59,6 +59,55 @@ class Foo5():
         self.baz: str = baz
 
 
+class Foo6():
+    def __init__(self, foo: Optional['Foo6'] = None):
+        self.foo: Optional['Foo6'] = foo
+
+    @standard_representation
+    def __repr__(self) -> str:
+        pass  # pragma: no cover
+
+
+foo6 = Foo6()
+foo6.foo = foo6
+
+
+class Foo7():
+    def __init__(self, foo: Optional['Foo7'] = None):
+        self.foo: Optional['Foo7'] = foo
+
+    @standard_representation
+    def __repr__(self) -> str:
+        pass  # pragma: no cover
+
+
+foo7 = Foo7(Foo7())
+foo7.foo = Foo7()
+foo7.foo.foo = foo7
+
+
+class Foo8():
+    def __init__(self, bar: 'Bar8'):
+        self.bar: 'Bar8' = bar
+
+    @standard_representation
+    def __repr__(self) -> str:
+        pass  # pragma: no cover
+
+
+class Bar8():
+    def __init__(self, foo: Optional['Foo8'] = None):
+        self.foo: Optional['Foo8'] = foo
+
+    @standard_representation
+    def __repr__(self) -> str:
+        pass  # pragma: no cover
+
+
+bar8 = Bar8()
+foo8 = Foo8(bar8)
+bar8.foo = foo8
+
 # pylint: enable=disallowed-name
 
 
@@ -70,7 +119,9 @@ class Foo5():
     (Foo3(1, 'spam'), None, "Foo3(1, 'spam')"),
     (Foo4(bar=1), None, 'Foo4(bar=1)'),
     (Foo4a(1), {'bar': 'wibble'}, 'Foo4a(bar=1)'),
-    (Foo5(1), None, 'Foo5(1)'),
+    (foo6, None, 'Foo6(foo=<..>)'),
+    (foo7, None, 'Foo7(foo=Foo7(foo=<...>))'),
+    (foo8, None, 'Foo8(Bar8(foo=<...>))'),
 ])
 # yapf: enable
 def test_standard_reprsentation(instance: Any, parameter_to_attribute_name: Dict[str, str],


### PR DESCRIPTION
Add the ability for the standard representation to better handle
recursive representations. The implementation relies on marking standard
representation methods with a special attribute which isn't very clean,
but I'm not aware of a better way to do this at this time?