### PR TITLE
Add string join

### DIFF
--- a/seligimus/strings/join.py
+++ b/seligimus/strings/join.py
@@ -1,0 +1,31 @@
+"""Join strings with seperators and optionally a different final seperator."""
+from typing import Iterable, Iterator, Optional
+
+
+def join(strings: Iterable[str], seperator: str = '', final: Optional[str] = None) -> str:
+    """Join strings with seperators and optionally a different final seperator."""
+    string: str = ''
+
+    iterator: Iterator[str] = iter(strings)
+    try:
+        string = next(iterator)
+    except StopIteration:
+        return string
+
+    try:
+        next_string: str = next(iterator)
+    except StopIteration:
+        return string
+
+    while True:
+        try:
+            next_next_string = next(iterator)
+        except StopIteration:
+            final = final if final is not None else seperator
+            string += final + next_string
+            break
+
+        string += seperator + next_string
+        next_string = next_next_string
+
+    return string

--- a/tests/strings/test_join.py
+++ b/tests/strings/test_join.py
@@ -1,0 +1,28 @@
+"""Test seligimus.strings.join."""
+from typing import Any, Dict, List
+
+import pytest
+
+from seligimus.strings.join import join
+
+
+# yapf: disable
+@pytest.mark.parametrize('arguments, keyword_arguments, expected_string', [
+    ([[], ''], {}, ''),
+    ([['foo'], ', '], {}, 'foo'),
+    ([['foo', 'bar'], ', '], {}, 'foo, bar'),
+    ([['foo', 'bar', 'baz'], ', '], {}, 'foo, bar, baz'),
+    ([['foo', 'bar', 'baz'], ' + '], {}, 'foo + bar + baz'),
+    ([[], ', '], {'final': ' and '}, ''),
+    ([['foo'], ', '], {'final': ' and '}, 'foo'),
+    ([['foo', 'bar'], ', '], {'final': ' and '}, 'foo and bar'),
+    ([['foo', 'bar', 'baz'], ', '], {'final': ' and '}, 'foo, bar and baz'),
+    ([['foo', 'bar', 'baz', 'wibble'], ', '], {'final': ' and '}, 'foo, bar, baz and wibble'),
+])
+# yapf: enable
+def test_join(arguments: List[str], keyword_arguments: Dict[str, Any],
+              expected_string: str) -> None:
+    """Test seligimus.strings.join.join."""
+    string: str = join(*arguments, **keyword_arguments)
+
+    assert string == expected_string


### PR DESCRIPTION
Add the ability to join strings with seperatos and optionally a
different final seperator. For example, you can join the strings 'foo',
'bar', and 'baz' into 'foo, bar or baz'. The next thing for this would be
to add support for a different seperator depending on whether there are
only two, or two or more seperators (this would let you do Oxford
commas.) We might also figure out a better looping mechanism? For
example something that lets you loop through an iterable with a kernel
of current value, next value or size kernels?